### PR TITLE
feat: 공유 데이터 페이지 구현 및 UI 개선

### DIFF
--- a/src/data/sharedDataDummyData.ts
+++ b/src/data/sharedDataDummyData.ts
@@ -1,0 +1,27 @@
+// 공유 데이터 조회 응답 타입
+export interface SharedPoolData {
+  poolTotalData: number; // 총 공유 데이터 (MB)
+  poolRemainingData: number; // 남은 공유 데이터 (MB)
+  pool_base_data: number; // 기본 공유 데이터 (MB)
+  monthlyUsageAmount: number; // 월간 사용량 (MB)
+  monthlyContributionAmount: number; // 월간 기여량 (MB)
+}
+
+// 데이터 이체 요청 타입
+export interface DataTransferRequest {
+  fromLineId: number;
+  toLineId: number;
+  amount: number; // MB 단위
+}
+
+// 더미 데이터
+export const dummySharedPoolData: SharedPoolData = {
+  poolTotalData: 60000, // 60GB
+  poolRemainingData: 20000, // 20GB
+  pool_base_data: 40000, // 40GB (기본 공유)
+  monthlyUsageAmount: 40000, // 40GB 사용
+  monthlyContributionAmount: 20000, // 20GB 기여 (가족 추가)
+};
+
+// 잔여 기간 (일)
+export const remainingDays = 9;

--- a/src/page/Main/MainPage.tsx
+++ b/src/page/Main/MainPage.tsx
@@ -72,7 +72,7 @@ export default function Main() {
       </div>
 
       {/* 공유 데이터 담기 페이지 이동 버튼 */}
-      <GradientButton onClick={() => navigate("/shared-pool/add")}>
+      <GradientButton onClick={() => navigate("/shared-data")}>
         <img src={PlusIcon} className="w-5 h-5" />
         가족 공유 데이터 담기
       </GradientButton>

--- a/src/page/Setting.tsx
+++ b/src/page/Setting.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useSettingStore } from '../store/settingStore';
 import Toggle from '../components/common/Toggle';
+import RangeSlider from '../components/common/RangeSlider';
 
 /**
  * 정보 툴팁 컴포넌트
@@ -259,22 +260,17 @@ export default function Setting() {
                 
                 {personalDataThresholdEnabled && (
                   <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1 relative">
-                        <input
-                          type="range"
-                          min="0"
-                          max="10000"
-                          step="50"
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="flex-1">
+                        <RangeSlider
                           value={personalDataThreshold}
-                          onChange={(e) => handleThresholdChange(Number(e.target.value))}
-                          className="w-full h-2 rounded-lg appearance-none cursor-pointer slider-custom"
-                          style={{
-                            background: `linear-gradient(to right, #678BF7 0%, #9A9CEA ${(personalDataThreshold / 10000) * 100}%, #E0E0E0 ${(personalDataThreshold / 10000) * 100}%, #E0E0E0 100%)`
-                          }}
+                          onChange={handleThresholdChange}
+                          min={0}
+                          max={10000}
+                          step={50}
                         />
                       </div>
-                      <div className="flex items-center ml-3">
+                      <div className="flex items-center">
                         <input
                           type="number"
                           value={personalDataThreshold}

--- a/src/page/SharedData/SharedData.tsx
+++ b/src/page/SharedData/SharedData.tsx
@@ -1,0 +1,95 @@
+import { useNavigate } from 'react-router-dom';
+import alarmIcon from '../../assets/icon/alarm-icon.png';
+import settingIcon from '../../assets/icon/setting-icon.png';
+import SharedPoolCard from './components/SharedPoolCard';
+import DataTransferCard from './components/DataTransferCard';
+import { dummySharedPoolData, remainingDays } from '../../data/sharedDataDummyData';
+
+export default function SharedData() {
+  const navigate = useNavigate();
+
+  // 더미 데이터
+  const personalDataRemaining = 15000; // 15GB (MB 단위)
+
+  const handleTransfer = (amount: number) => {
+    console.log('공유하기:', amount, 'MB');
+    // API 호출 로직
+    // POST /api/data-transfer
+    // body: { fromLineId: 1, toLineId: 2, amount: amount }
+    navigate('/');
+  };
+
+  return (
+    <>
+      {/* 커스텀 헤더 */}
+      <header className="fixed top-6 left-1/2 -translate-x-1/2 w-[480px] max-w-full flex justify-between items-center px-5 h-20 pt-[env(safe-area-inset-top)] z-[100]">
+        <div className="flex items-center w-20">
+          <button 
+            type="button"
+            aria-label="뒤로 가기"
+            className="p-1 bg-transparent border-none cursor-pointer flex items-center justify-center" 
+            onClick={() => navigate(-1)}
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M15 18L9 12L15 6" stroke="#333333" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 flex justify-center items-center">
+          <h1 className="font-semibold text-[#333333] m-0" style={{ fontSize: '1.25em' }}>가족 공유 풀</h1>
+        </div>
+
+        <div className="flex items-center gap-3 w-20 justify-end">
+          <button 
+            type="button"
+            aria-label="알림"
+            className="relative cursor-pointer flex items-center justify-center w-12 h-12 rounded-full shrink-0 border-[3px] border-white bg-gradient-to-b from-white/0 to-white/100 to-42%"
+            onClick={() => navigate('/alarm')}
+          >
+            <img src={alarmIcon} alt="" className="w-6 h-6" />
+            <div className="absolute -top-1 -right-1 min-w-[20px] h-5 px-1.5 bg-[#FF0000] rounded-full flex items-center justify-center">
+              <span className="text-white text-[10px] font-bold leading-none">3</span>
+            </div>
+          </button>
+          <button 
+            type="button"
+            aria-label="설정"
+            className="cursor-pointer flex items-center justify-center w-12 h-12 rounded-full shrink-0 border-[3px] border-white bg-gradient-to-b from-white/0 to-white/100 to-42%"
+            onClick={() => navigate('/setting')}
+          >
+            <img src={settingIcon} alt="" className="w-6 h-6" />
+          </button>
+        </div>
+      </header>
+
+      <div className="relative h-[calc(100vh-106px-60px)] overflow-y-auto mt-[106px] mb-[60px]">
+        <div className="py-5 pb-[40px]">
+          {/* 총 공유 데이터 카드 */}
+          <div className="px-6">
+            <SharedPoolCard
+              totalData={dummySharedPoolData.poolTotalData}
+              remainingData={dummySharedPoolData.poolRemainingData}
+              baseData={dummySharedPoolData.pool_base_data}
+              contributionData={dummySharedPoolData.monthlyContributionAmount}
+              usageAmount={dummySharedPoolData.monthlyUsageAmount}
+              remainingDays={remainingDays}
+            />
+          </div>
+
+          {/* 공유 데이터 담기 */}
+          <div className="px-6">
+            <h3 className="text-lg font-medium text-gray-800 mb-4">공유 데이터 담기</h3>
+            
+            <DataTransferCard
+              personalDataRemaining={personalDataRemaining}
+              poolTotalData={dummySharedPoolData.poolTotalData}
+              onTransfer={handleTransfer}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+

--- a/src/page/SharedData/components/DataTransferCard.tsx
+++ b/src/page/SharedData/components/DataTransferCard.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+
+interface DataTransferCardProps {
+  personalDataRemaining: number; // MB
+  poolTotalData: number; // MB
+  onTransfer: (amount: number) => void;
+}
+
+export default function DataTransferCard({
+  personalDataRemaining,
+  poolTotalData,
+  onTransfer
+}: DataTransferCardProps) {
+  const [sharedAmount, setSharedAmount] = useState(3);
+
+  const personalGB = (personalDataRemaining / 1000).toFixed(0);
+  const poolGB = (poolTotalData / 1000).toFixed(1);
+
+  const handleIncrement = () => {
+    setSharedAmount(prev => Math.min(prev + 1, 60));
+  };
+
+  const handleDecrement = () => {
+    setSharedAmount(prev => Math.max(prev - 1, 0));
+  };
+
+  const handleInputChange = (value: string) => {
+    const numValue = parseInt(value) || 0;
+    setSharedAmount(Math.min(Math.max(numValue, 0), 60));
+  };
+
+  const handleShare = () => {
+    onTransfer(sharedAmount * 1000); // GB를 MB로 변환
+  };
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl p-6 shadow-sm mb-6">
+        <div className="flex items-center gap-2 mb-6">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" stroke="#678BF7" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <circle cx="12" cy="7" r="4" stroke="#678BF7" strokeWidth="2"/>
+          </svg>
+          <span className="font-normal text-gray-800">개인 데이터 잔여량: <span className="font-medium">{personalGB}GB</span></span>
+        </div>
+
+        <div className="mb-8">
+          <div className="flex justify-between items-start mb-3">
+            <div className="flex-1 text-center">
+              <div className="text-sm mb-1" style={{ color: '#9CA3AF' }}>총 공유 데이터</div>
+              <div className="text-2xl font-medium" style={{ color: '#678BF7' }}>{sharedAmount} GB</div>
+            </div>
+            <div className="flex-1 text-center">
+              <div className="text-sm mb-1" style={{ color: '#9CA3AF' }}>충전 데이터 한도</div>
+              <div className="text-2xl font-medium" style={{ color: '#6B7280' }}>{poolGB} GB</div>
+            </div>
+          </div>
+        </div>
+
+        {/* 입력 컨트롤 */}
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={handleDecrement}
+            className="w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-xl shrink-0"
+            style={{ background: 'linear-gradient(135deg, #678BF7, #9A9CEA)' }}
+          >
+            −
+          </button>
+          
+          <div className="relative flex items-center justify-center w-40">
+            <input
+              type="number"
+              value={sharedAmount}
+              onChange={(e) => handleInputChange(e.target.value)}
+              className="w-full h-[52px] text-center text-xl font-semibold rounded-xl focus:outline-none focus:border-[#D0D0D0] [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              style={{ borderColor: '#D0D0D0', borderWidth: '0.3px', borderStyle: 'solid', paddingRight: '32px' }}
+              min="0"
+              max="60"
+            />
+            <span className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 text-base pointer-events-none">GB</span>
+          </div>
+
+          <button
+            onClick={handleIncrement}
+            className="w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-xl shrink-0"
+            style={{ background: 'linear-gradient(135deg, #678BF7, #9A9CEA)' }}
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      {/* 안내 문구 */}
+      <div className="space-y-0.5 mb-4 px-[34px]">
+        <p className="text-xs" style={{ color: '#868A8A' }}>• 개인 데이터 잔여량이 1GB 이상일 때만 전송 가능합니다</p>
+        <p className="text-xs" style={{ color: '#868A8A' }}>• 데이터는 1GB 단위로 전송할 수 있습니다.</p>
+        <p className="text-xs" style={{ color: '#868A8A' }}>• 전송 완료 후에는 취소가 불가능하니 주의해주세요</p>
+      </div>
+
+      {/* 공유하기 버튼 */}
+      <div className="px-[34px]">
+        <button
+          onClick={handleShare}
+          className="w-full py-4 rounded-[18px] text-white font-semibold text-xl flex items-center justify-center gap-2 relative overflow-hidden"
+          style={{ background: 'linear-gradient(135deg, #678BF7, #9A9CEA)' }}
+        >
+          {/* 그라데이션 외곽선 */}
+          <div 
+            className="absolute inset-0 rounded-[18px]"
+            style={{
+              padding: '3px',
+              background: 'linear-gradient(to right, rgba(255, 255, 255, 0.6), #678BF7)',
+              WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+              WebkitMaskComposite: 'xor',
+              maskComposite: 'exclude'
+            }}
+          />
+          <span className="relative z-10">공유하기</span>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" className="relative z-10">
+            <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/page/SharedData/components/SharedPoolCard.tsx
+++ b/src/page/SharedData/components/SharedPoolCard.tsx
@@ -1,0 +1,101 @@
+import { useNavigate } from 'react-router-dom';
+
+interface SharedPoolCardProps {
+  totalData: number; // MB
+  remainingData: number; // MB
+  baseData: number; // MB
+  contributionData: number; // MB
+  usageAmount: number; // MB
+  remainingDays: number;
+}
+
+export default function SharedPoolCard({
+  totalData,
+  remainingData,
+  baseData,
+  contributionData,
+  usageAmount,
+  remainingDays
+}: SharedPoolCardProps) {
+  const navigate = useNavigate();
+  
+  const totalGB = (totalData / 1000).toFixed(1);
+  const baseGB = (baseData / 1000).toFixed(1);
+  const contributionGB = (contributionData / 1000).toFixed(1);
+  const usageGB = (usageAmount / 1000).toFixed(1);
+  const usagePercent = (usageAmount / totalData) * 100;
+
+  return (
+    <div className="bg-white rounded-2xl p-6 mb-6 shadow-sm">
+      <div className="flex justify-between items-start mb-1">
+        <h2 className="text-[15px] font-medium" style={{ color: '#808692' }}>총 공유 데이터</h2>
+        <span className="text-xs font-medium mr-2 mt-1" style={{ color: '#BA7E7D' }}>
+          잔여 기간 {remainingDays}일
+        </span>
+      </div>
+      
+      <div className="mb-2 mt-3">
+        <div className="flex justify-between items-center mb-2">
+          <div className="text-[30px] font-semibold" style={{ color: '#678BF7' }}>
+            {totalGB} GB
+          </div>
+          <button 
+            onClick={() => navigate('/shared-data/usage')}
+            className="px-6 py-2.5 rounded-lg text-xs font-medium text-white flex items-center gap-1.5 relative overflow-hidden"
+            style={{
+              background: 'rgba(103, 139, 247, 0.6)'
+            }}
+          >
+            {/* 그라데이션 외곽선 */}
+            <div 
+              className="absolute inset-0 rounded-lg"
+              style={{
+                padding: '1.5px',
+                background: 'linear-gradient(to right, rgba(255, 255, 255, 0.6), #678BF7)',
+                WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+                WebkitMaskComposite: 'xor',
+                maskComposite: 'exclude'
+              }}
+            />
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="relative z-10">
+              <path d="M9 11l3 3L22 4" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+            <span className="relative z-10">사용 로그 보기</span>
+          </button>
+        </div>
+        <div className="flex gap-8 text-sm">
+          <div>
+            <span style={{ color: '#9CA3AF' }}>기본 공유</span>
+            <div className="font-medium text-base" style={{ color: '#374151' }}>{baseGB} GB</div>
+          </div>
+          <div>
+            <span style={{ color: '#9CA3AF' }}>가족 추가</span>
+            <div className="font-medium text-base" style={{ color: '#374151' }}>{contributionGB} GB</div>
+          </div>
+        </div>
+      </div>
+
+      {/* 구분선 */}
+      <div className="mx-4 mb-3 border-t" style={{ borderColor: '#F3F4F6' }} />
+
+      <div className="mb-2">
+        <div className="text-xs mb-2" style={{ color: '#9CA3AF' }}>
+          <span>현재 사용량</span>
+        </div>
+        <div className="flex items-center gap-3 text-xs" style={{ color: '#9CA3AF' }}>
+          <div className="flex-1 h-3 rounded-full bg-gray-100 overflow-hidden">
+            <div 
+              className="h-full rounded-full transition-all duration-500"
+              style={{ 
+                width: `${usagePercent}%`,
+                background: 'linear-gradient(to right, #678BF7, #9A9CEA)'
+              }}
+            />
+          </div>
+          <span className="whitespace-nowrap">사용 {usageGB}GB / 잔여 {(remainingData / 1000).toFixed(1)}GB</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/page/Support.tsx
+++ b/src/page/Support.tsx
@@ -155,7 +155,7 @@ export default function Support() {
       <div className="bg-[#E8E8E8] rounded-2xl p-1 mx-9 mb-6 flex gap-1 justify-center">
         <button
           onClick={() => setActiveTab('inquiry')}
-          className={`px-[70px] py-2 rounded-2xl font-medium transition-colors text-sm ${
+          className={`px-[70px] py-2 rounded-2xl font-medium transition-colors text-sm whitespace-nowrap ${
             activeTab === 'inquiry'
               ? 'bg-white text-[#219BE4]'
               : 'bg-transparent text-[#999999]'
@@ -166,7 +166,7 @@ export default function Support() {
         </button>
         <button
           onClick={() => setActiveTab('history')}
-          className={`px-[70px] py-2 rounded-2xl font-medium transition-colors text-sm ${
+          className={`px-[70px] py-2 rounded-2xl font-medium transition-colors text-sm whitespace-nowrap ${
             activeTab === 'history'
               ? 'bg-white text-[#219BE4]'
               : 'bg-transparent text-[#999999]'

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -9,6 +9,7 @@ import Setting from "../page/Setting";
 import Detail from "../page/Detail";
 import PolicyDetail from "../page/PolicyDetail/PolicyDetail";
 import NotFound from "../page/NotFound";
+import SharedData from "../page/SharedData/SharedData";
 import StatusBar from "../components/StatusBar";
 import Header from "../components/Header";
 import BottomBar from "../components/BottomBar";
@@ -28,6 +29,7 @@ export default function Router() {
           <Route path="/setting" element={<Setting />} />
           <Route path="/detail" element={<Detail />} />
           <Route path="/policy-detail" element={<PolicyDetail />} />
+          <Route path="/shared-data" element={<SharedData />} />
           <Route path="/404" element={<NotFound />} />
           <Route path="*" element={<Navigate to="/404" replace />} />
         </Routes>


### PR DESCRIPTION
## 이슈
- closed #22 

## ✔️  체크리스트
- [x] : Merge할 브랜치를 확인해 주세요.

## 🔍 작업 내용
- 공유 데이터 페이지 컴포넌트 구조 분리 (SharedPoolCard, DataTransferCard)
- 총 공유 데이터 카드 사용량 시각화, 사용 로그 보기 버튼 추가
- 데이터 이체 카드
- RangeSlider 공통 컴포넌트를 Setting 페이지에 적용
- 고객지원 페이지 텍스트 줄바꿈 이슈 수정
- API 명세서 기반 더미 데이터 및 타입 정의 추가
<img width="470" height="942" alt="image" src="https://github.com/user-attachments/assets/d5d3519c-4ad1-456c-8656-1ee79b84f410" />

## ⚠️ 주의 사항 / 기타
API 연결 필요