### PR TITLE
fix: 머지 충돌로 인한 중복 코드 제거 및 타입 에러 수정

### DIFF
--- a/src/api/services/questionService.ts
+++ b/src/api/services/questionService.ts
@@ -179,20 +179,6 @@ export const questionService = {
     return response.data;
   },
 
-  // 답변 생성
-  createAnswer: async (data: { questionId: number; content: string; attachments?: { s3Key: string; fileSize: number }[] }) => {
-    const response = await apiClient.post<{ answerId: number }>('/answers', data);
-    return response.data;
-  },
-
-  // 답변 삭제
-  deleteAnswer: async (answerId: number) => {
-    const response = await apiClient.delete('/answers', {
-      params: { answerId },
-    });
-    return response.data;
-  },
-
   // [어드민] 문의사항 목록 조회
   getAdminQuestions: async (params: {
     pageNumber: number;

--- a/src/page/Admin/components/policy/BlockPolicyManager.tsx
+++ b/src/page/Admin/components/policy/BlockPolicyManager.tsx
@@ -482,7 +482,7 @@ export default function BlockPolicyManager({ lineId, onPolicyChange }: Props) {
   const updatePolicyOptimistically = async (
     id: number,
     updater: (policies: BlockPolicy[]) => BlockPolicy[],
-    apiCall: () => Promise<unknown>,
+    apiCall: () => Promise<{ data: RepeatBlockPolicy }>,
     successMessage?: string
   ) => {
     const prevPolicies = [...policies];


### PR DESCRIPTION
## ✔️  체크리스트
- [x] : Merge할 브랜치를 확인해 주세요.

## 🔍 작업 내용
- questionService.ts의 중복된 createAnswer, deleteAnswer 메서드 제거
- BlockPolicyManager.tsx의 updatePolicyOptimistically 함수 타입을 Promise<{ data: RepeatBlockPolicy }>로 명확히 지정

## ⚠️ 주의 사항 / 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 질문에 대한 답변 생성 및 삭제 기능이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->