### PR TITLE
fix: 메인 페이지 모바일로 로그인시 UI 깨짐 해결

### DIFF
--- a/src/page/Main/MainPage.tsx
+++ b/src/page/Main/MainPage.tsx
@@ -22,7 +22,7 @@ export default function Main() {
   // 현재 로그인한 사용자가 대표자인가
   const isOwner = userData?.role === "OWNER";
 
-  const { data: familyData, isLoading: isFamilyLoading } =
+  const { data: familyData, isPending: isFamilyLoading } =
     useQuery<FamilyApiResponse>({
       queryKey: ["familyMembers"],
       queryFn: () => familyService.getMembers().then((res) => res.data),
@@ -53,7 +53,7 @@ export default function Main() {
     color: COLORS[index % COLORS.length],
   }));
 
-  const { data: sharedPoolData, isLoading: isPoolLoading } =
+  const { data: sharedPoolData, isPending: isPoolLoading } =
     useQuery<SharedData>({
       queryKey: ["sharedPool"],
       queryFn: () => sharedPoolService.getMainRemainingAmount(),

--- a/src/page/Main/components/MemberCard.tsx
+++ b/src/page/Main/components/MemberCard.tsx
@@ -55,7 +55,9 @@ export default function FamilyMemberCard({
             {canViewDetail && (
               <button
                 onClick={() =>
-                  navigate("/detail", { state: { lineId: member.lineId, userName: member.userName } })
+                  navigate("/detail", {
+                    state: { lineId: member.lineId, userName: member.userName },
+                  })
                 }
                 className="flex items-center justify-center gap-0.2 text-xs text-[#0F4E7A] hover:text-[#4A7FB5] transition-colors"
               >
@@ -91,7 +93,7 @@ export default function FamilyMemberCard({
       {/* 데이터 막대 그래프 */}
       <div className="flex flex-col gap-3">
         <DataBar
-          label="기본 데이터"
+          label="기본 데이터 잔여량"
           remaining={member.remainingData}
           total={member.basicDataAmount}
           color="#ADE6FF"
@@ -99,7 +101,7 @@ export default function FamilyMemberCard({
         {(member.sharedPoolTotalAmount === -1 ||
           member.sharedPoolTotalAmount > 0) && (
           <DataBar
-            label="제공받은 공유데이터"
+            label="제공받은 공유데이터 잔여량"
             remaining={member.sharedPoolRemainingAmount}
             total={member.sharedPoolTotalAmount}
             color="#9A9CEA"


### PR DESCRIPTION
## 이슈
- closed #이슈번호

## ✔️  체크리스트
- [x] : Merge할 브랜치를 확인해 주세요.

## 🔍 작업 내용
- 모바일로 로그인 할 때 pieChart가 헤더랑 겹치는 에러 수정

## ⚠️ 주의 사항 / 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 회원 카드의 데이터 표시 레이블 업데이트: 기본 데이터 및 공유 데이터 항목에 "잔여량" 텍스트 추가하여 표시되는 수치가 남은 용량임을 명확히 함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->